### PR TITLE
Fix Slack URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@
                           <i class="fa fa-meetup fa-fw" aria-hidden="true"></i> <span class="network-name">Meetup</span></a>
                     </li>
                     <li>
-                        <a href="https://slack-opensanca.herokuapp.com//" class="btn btn-default btn-lg" target="_blank">
+                        <a href="https://opensanca.signup.team" class="btn btn-default btn-lg" target="_blank">
                           <i class="fa fa-slack fa-fw" aria-hidden="true"></i> <span class="network-name">Slack</span></a>
                     </li>
                 </ul>


### PR DESCRIPTION
The current slack url is wrong. (two dashes at the end).
Changed to our new signup url.