### PR TITLE
Migrate to Gulp 4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var concat = require( 'gulp-concat' );
 var nano = require('gulp-cssnano' );
 var handlebars = require( 'gulp-compile-handlebars' );
 var rename = require( 'gulp-rename' );
-var files = [ 'index.html', '../assets/css/style.css' ];
+var files = [ 'index.html', './assets/css/styles.css' ];
 var handlebarsFiles = [ './views/**/*', eventFile ];
 var _ = require('lodash');
 
@@ -51,16 +51,17 @@ gulp.task( 'files', function() {
   gulp.src( files ).pipe( connect.reload() );
 });
 
+// Watch files
 gulp.task( 'watch', function() {
-  gulp.watch( files, [ 'files' ]);
-  gulp.watch( handlebarsFiles, [ 'hbs' ]);
-  gulp.watch( './src/css/**/*', [ 'hbs' ]);
+  gulp.watch( files, gulp.series('files'));
+  gulp.watch( handlebarsFiles, gulp.series('hbs'));
+  gulp.watch( './src/css/**/*', gulp.series('hbs'));
 });
 
 gulp.task( 'connect', function() {
   connect.server({ livereload: true });
 });
 
-gulp.task('build', [ 'hbs', 'css' ]);
+gulp.task('build', gulp.parallel('hbs', 'css'))
 
-gulp.task('default', [ 'build', 'connect', 'watch' ]);
+gulp.task('default', gulp.parallel('build', 'connect', 'watch'))

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "font-awesome": "^4.7.0"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-concat": "^2.6.1",
     "gulp-connect": "^5.0.0",


### PR DESCRIPTION
Currently we can't run on Node >= 12 because Gulp 3 can't support it.
This PR upgrades our Gulp to version 4.

- Changes the gulpfile.js to use the new pattern of Gulp 4 to execute
other tasks (using .series or .parallel)